### PR TITLE
Specify a commit hash for the jsdoc-baseline package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "moment": "^2.14.1"
   },
   "devDependencies": {
-    "jsdoc-baseline": "https://github.com/dennybiasiolli/jsdoc-baseline/tarball/master"
+    "jsdoc-baseline": "https://github.com/dennybiasiolli/jsdoc-baseline/tarball/222e13a"
   },
   "scripts": {
     "test": "node test"


### PR DESCRIPTION
I plan to make breaking changes to the hegemonic/jsdoc-baseline repo. To ensure that your repo is not affected by these breaking changes, this pull request pins the `jsdoc-baseline` package to a specific commit hash.

If you prefer, you can use the [NPM release of this package](https://www.npmjs.com/package/jsdoc-baseline) instead by setting the `jsdoc-baseline` property to `^0.1.1`.